### PR TITLE
feat: support extra env/secrets and optional wiki documentation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,58 @@ calculate SLOs for
 Please check the input tab of [this module's page][input tab] on terraform 
 registry to see all available options and their descriptions. 
 
+To pass extra environment variables to the generator container, use `extra-env`
+for plain values and `env-from-secrets` to inject existing Kubernetes Secrets via
+`envFrom`:
+
+```terraform
+  extra-env = {
+    SOME_FLAG = "true"
+  }
+
+  env-from-secrets = ["my-synced-secret"]
+```
+
+The Secrets named in `env-from-secrets` must already exist in the namespace when
+the deployment rolls out — the module references them by name and cannot order
+its rollout after a Secret it does not manage, so a pod consuming a not-yet-ready
+Secret will sit in `CreateContainerConfigError` until it appears. Note also that
+`envFrom` precedence between multiple referenced Secrets is not guaranteed (keys
+are deduplicated, not ordered), so avoid relying on one Secret overriding a key
+of another.
+
+### Wiki documentation
+
+The generator can publish per-team documentation to Confluence. Enabling it
+syncs the Confluence credentials from Vault into a Kubernetes Secret (via the
+[External Secrets Operator][eso]) and wires them into the container, so each
+consuming team only sets two inputs:
+
+```terraform
+  wiki-enabled = true
+  team         = "my-team"
+```
+
+**Prerequisites.** The [External Secrets Operator][eso] must be installed in the
+cluster — the module creates an `ExternalSecret` (`external-secrets.io/v1beta1`)
+and that CRD has to exist, otherwise `terraform plan` fails to resolve the
+resource. The namespace also needs a `SecretStore` (named after the namespace by
+default) with read access to the credentials' Vault path.
+
+When enabled, terraform waits for the operator to report the `ExternalSecret` as
+Ready (so the backing Secret exists before the generator rolls out) and fails the
+apply if that does not happen within `wiki-secret-wait-timeout`. This wait
+applies only when `wiki-enabled = true`; with the feature off the core
+deployment has no dependency on it.
+
+The Vault key, the property names read from it, the store name/kind, the refresh
+interval and the wait timeout can all be overridden — see
+`wiki-confluence-vault-key`, `wiki-confluence-secret-keys`,
+`wiki-secret-store-name`, `wiki-secret-store-kind` (use `ClusterSecretStore` for
+a cluster-scoped store), `wiki-secret-refresh-interval` and
+`wiki-secret-wait-timeout` in the inputs.
+
+[eso]: https://external-secrets.io/
 [omni-slo-generator]: https://github.com/heureka/omni-slo-generator
 [slo-generator]: https://github.com/google/slo-generator/
 [input tab]: https://registry.terraform.io/modules/heureka/google-slo-generator/kubernetes/latest?tab=inputs

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,19 @@ locals {
     "app.kubernetes.io/managed-by" = "terraform-kubernetes-google-slo-generator"
     "app.kubernetes.io/version"    = var.generator-version
   })
+
+  # Name of the Secret synced from Vault (via ExternalSecret) holding the
+  # Confluence credentials when the wiki feature is enabled.
+  wiki_secret_name = "${local.name}-confluence"
+
+  # Plain wiki env vars set on the container when the feature is enabled.
+  # The Confluence credentials themselves come via envFrom (wiki_secret_name).
+  wiki_env = var.wiki-enabled ? {
+    OMNI_SLO_GENERATOR_WIKI_ENABLED = "true"
+    OMNI_SLO_GENERATOR_TEAM         = var.team
+  } : {}
+
+  wiki_secrets = var.wiki-enabled ? [local.wiki_secret_name] : []
 }
 
 resource "google_service_account" "slo-generator" {
@@ -55,6 +68,19 @@ resource "kubernetes_service_account" "slo-generator" {
 }
 
 resource "kubernetes_deployment" "slo-generator" {
+  # When the wiki feature is on, the container consumes the Confluence Secret via
+  # envFrom. That Secret is produced by the ExternalSecret below, but the
+  # reference goes through computed locals, so there is no implicit graph edge —
+  # make it explicit so the ExternalSecret is created before the rollout.
+  depends_on = [kubernetes_manifest.wiki-confluence-secret]
+
+  lifecycle {
+    precondition {
+      condition     = !var.wiki-enabled || trimspace(var.team) != ""
+      error_message = "team must be set to a non-empty value when wiki-enabled is true."
+    }
+  }
+
   metadata {
     name      = local.name
     namespace = var.namespace
@@ -84,6 +110,21 @@ resource "kubernetes_deployment" "slo-generator" {
           env {
             name  = "OMNI_SLO_GENERATOR_INTERVAL_SECONDS"
             value = var.scrape_interval_seconds
+          }
+          dynamic "env" {
+            for_each = merge(var.extra-env, local.wiki_env)
+            content {
+              name  = env.key
+              value = env.value
+            }
+          }
+          dynamic "env_from" {
+            for_each = toset(concat(local.wiki_secrets, var.env-from-secrets))
+            content {
+              secret_ref {
+                name = env_from.value
+              }
+            }
           }
           volume_mount {
             mount_path = "/etc/config/config.yaml"
@@ -122,6 +163,64 @@ resource "kubernetes_deployment" "slo-generator" {
         }
       }
     }
+  }
+}
+
+# Wiki documentation feature: sync Confluence credentials from Vault into a
+# Kubernetes Secret via the External Secrets Operator, then inject them as env
+# vars (envFrom) on the container. Requires the namespace's SecretStore to have
+# read access to the source Vault path (e.g. enabling common secrets for the
+# project). The SecretStore is assumed to be named after the namespace.
+resource "kubernetes_manifest" "wiki-confluence-secret" {
+  count = var.wiki-enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "external-secrets.io/v1beta1"
+    kind       = "ExternalSecret"
+    metadata = {
+      name      = local.wiki_secret_name
+      namespace = var.namespace
+      labels    = local.labels
+    }
+    spec = {
+      refreshInterval = var.wiki-secret-refresh-interval
+      secretStoreRef = {
+        name = var.wiki-secret-store-name == "" ? var.namespace : var.wiki-secret-store-name
+        kind = var.wiki-secret-store-kind
+      }
+      target = {
+        name = local.wiki_secret_name
+      }
+      data = [
+        for key in var.wiki-confluence-secret-keys : {
+          secretKey = key
+          remoteRef = {
+            key      = var.wiki-confluence-vault-key
+            property = key
+          }
+        }
+      ]
+    }
+  }
+
+  # Block the apply until ESO reports the ExternalSecret as Ready, which means
+  # the backing Kubernetes Secret has actually been synced from Vault and
+  # exists. Combined with the deployment's depends_on, this ensures the
+  # container does not roll out before the secret it consumes via envFrom is
+  # present (avoiding a first-apply CreateContainerConfigError race).
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  # Fail fast instead of blocking the whole apply indefinitely: if ESO cannot
+  # sync the secret (missing Vault key, misconfigured store, missing CRD), the
+  # wait above errors after this timeout with a clear signal rather than hanging.
+  timeouts {
+    create = var.wiki-secret-wait-timeout
+    update = var.wiki-secret-wait-timeout
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -108,3 +108,83 @@ variable "scrape_interval_seconds" {
 
   default = 30
 }
+
+variable "extra-env" {
+  type        = map(string)
+  description = "Additional plain (non-secret) environment variables to set on the generator container. Keys are env var names, values are their literal values."
+
+  default = {}
+}
+
+variable "env-from-secrets" {
+  type        = list(string)
+  description = "Names of existing Kubernetes Secrets (in the same namespace) whose keys are injected as environment variables via envFrom. Secret keys must be named exactly as the target env vars."
+
+  default = []
+}
+
+variable "wiki-enabled" {
+  type        = bool
+  description = "Enable the wiki documentation feature. Syncs the Confluence credentials from Vault into a Kubernetes Secret (via the External Secrets Operator) and injects them, along with the wiki env vars, into the generator container."
+
+  default = false
+}
+
+variable "team" {
+  type        = string
+  description = "Team this instance generates documentation for. Used as the parent page name and isolation guard. Required when wiki-enabled is true."
+
+  default = ""
+}
+
+variable "wiki-confluence-vault-key" {
+  type        = string
+  description = "Vault key (as resolved by the namespace's SecretStore) holding the Confluence credentials for the wiki feature."
+
+  default = "kv-common/slo-generator"
+}
+
+variable "wiki-confluence-secret-keys" {
+  type        = list(string)
+  description = "Property names to read from the Vault key and expose as env vars for the wiki feature. Each becomes both the env var name and the Vault property name, so they must match the names the generator expects."
+
+  default = [
+    "OMNI_SLO_GENERATOR_CONFLUENCE_TOKEN",
+    "OMNI_SLO_GENERATOR_CONFLUENCE_EMAIL",
+    "OMNI_SLO_GENERATOR_CONFLUENCE_SPACE_KEY",
+    "OMNI_SLO_GENERATOR_CONFLUENCE_ROOT_PAGE_ID",
+  ]
+}
+
+variable "wiki-secret-store-name" {
+  type        = string
+  description = "Name of the (Cluster)SecretStore to read the wiki credentials from. Defaults to the namespace name when empty."
+
+  default = ""
+}
+
+variable "wiki-secret-store-kind" {
+  type        = string
+  description = "Kind of the External Secrets store to read the wiki credentials from. Use ClusterSecretStore for cluster-scoped stores."
+
+  default = "SecretStore"
+
+  validation {
+    condition     = contains(["SecretStore", "ClusterSecretStore"], var.wiki-secret-store-kind)
+    error_message = "wiki-secret-store-kind must be either \"SecretStore\" or \"ClusterSecretStore\"."
+  }
+}
+
+variable "wiki-secret-wait-timeout" {
+  type        = string
+  description = "How long terraform waits for the External Secrets Operator to report the wiki ExternalSecret as Ready before failing the apply."
+
+  default = "3m"
+}
+
+variable "wiki-secret-refresh-interval" {
+  type        = string
+  description = "How often the External Secrets Operator re-reads the wiki credentials from Vault."
+
+  default = "1h"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = ">=3.79.0"
     }
   }
-  required_version = ">= 1.1.6"
+  required_version = ">= 1.2.0"
 }


### PR DESCRIPTION
Add generic escape hatches for injecting configuration into the generator container, plus an opinionated wiki documentation feature built on top:

- extra-env: additional plain environment variables
- env-from-secrets: inject existing Kubernetes Secrets via envFrom
- wiki-enabled: sync the Confluence credentials from Vault into a Kubernetes Secret via the External Secrets Operator (ExternalSecret) and inject them, along with the wiki env vars, into the container

Wiki specifics:
- gate the ExternalSecret and all wiki wiring on wiki-enabled (count); the core deployment has no dependency on it when the feature is off
- wait for the operator to report the ExternalSecret Ready before rollout, with a fail-fast timeout (wiki-secret-wait-timeout) instead of hanging
- precondition requiring team when wiki-enabled is true
- wiki env vars are authoritative over extra-env on key collision
- configurable store kind (SecretStore / ClusterSecretStore), store name, vault key, property keys and refresh interval
- raise required_version to >= 1.2.0 for the precondition
- document the ESO/CRD prerequisite and envFrom ordering/existence caveats